### PR TITLE
[dayshift] docs: add module-level docstring to __init__.py

### DIFF
--- a/src/elevenlabs_webui_client/__init__.py
+++ b/src/elevenlabs_webui_client/__init__.py
@@ -1,3 +1,15 @@
+"""ElevenLabs WebUI client — TTS synthesis via Firebase/WebUI authentication.
+
+Public API:
+
+- :func:`tts_to_mp3` — synthesize text to an MP3 file
+- :func:`get_subscription` — fetch subscription details
+- :func:`list_voices` — list available voices
+- :func:`extract_profile_auth` — extract tokens from a browser profile
+- :func:`sanitize_tts_text` — strip markdown from text before TTS
+- :func:`format_refresh_tokens_env_line` — format tokens as an env export line
+"""
+
 from .client import (
     extract_profile_auth,
     format_refresh_tokens_env_line,


### PR DESCRIPTION
Public API index covering all 6 exported functions.

Supersedes unique content from PR #1 (rest covered by PR #5).

Reviewed by: Dayshift